### PR TITLE
jar 生成

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build and Upload
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 13
+        java-package: jdk+fx
+    - name: build
+      run: gradle build
+    - name: culculate symbol
+      id: sym
+      run: |
+        ref='${{ github.ref }}'
+        sym=$(echo $ref | perl -e "print pop @{[split '/', <>]}")
+        echo "::set-output name=symbol::$sym"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dondondon-${{ steps.sym.outputs.symbol }}.zip
+        path: build/libs/dondondon-1.0-SNAPSHOT.jar

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,12 @@ sourceSets {
     }
 }
 
+jar {
+    manifest {
+        attributes 'Main-Class': 'Main'
+    }
+}
+
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 tasks.withType(AbstractCompile)*.options*.encoding = tasks.withType(GroovyCompile)*.groovyOptions*.encoding = 'UTF-8'


### PR DESCRIPTION
`java -jar dondondon-1.0-SNAPSHOT.jar` でコンソールに例外吐かれるけど起動までは確認済み。

Actions タブの最新の workflow にある Artifacts からダウンロードできる。
現状は push の度にビルドされるので、頻度はもう少し考えてもいいかも。

※ なお、このPRでもビルドされるはず。